### PR TITLE
add files in resources folder to sonarcloud analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,8 @@ jobs:
         -Dsonar.organization=heutelbeck
         -Dsonar.host.url=https://sonarcloud.io
         -Dsonar.projectKey=heutelbeck_sapl-demos
+        -Dsonar.sources=pom.xml,src/ 
+        -Dsonar.inclusions=**/pom.xml,**/src/main/java/**,**/src/main/resources/**
         -Dsonar.exclusions=**/xtext-gen/**/*,**/xtend-gen/**/*,**/emf-gen/**/*
         -Dsonar.java.spotbugs.reportPaths=target/spotbugsXml.xml
         -Dsonar.qualitygate.wait=true

--- a/.github/workflows/sonar_analysis_fork.yaml
+++ b/.github/workflows/sonar_analysis_fork.yaml
@@ -64,6 +64,8 @@ jobs:
         -Dsonar.host.url=https://sonarcloud.io
         -Dsonar.organization=heutelbeck
         -Dsonar.projectKey=heutelbeck_sapl-demos
+        -Dsonar.sources=pom.xml,src/ 
+        -Dsonar.inclusions=**/pom.xml,**/src/main/java/**,**/src/main/resources/**
         -Dsonar.exclusions=**/xtext-gen/**/*,**/xtend-gen/**/*,**/emf-gen/**/*
         -Dsonar.java.spotbugs.reportPaths=target/spotbugsXml.xml
         -Dsonar.pullrequest.key=${PR}


### PR DESCRIPTION
This pull request allows to include all files in the modules' src/main/resources folder in the SonarCloud analysis. SonarCloud does not include these files by default. 

The PR could be merged if these files need to be analyzed.